### PR TITLE
Added report file for ontology loading:

### DIFF
--- a/bio/ensembl/ontology/hive/OLSHiveLoader.py
+++ b/bio/ensembl/ontology/hive/OLSHiveLoader.py
@@ -48,9 +48,9 @@ class OLSHiveLoader(eHive.BaseRunnable):
         options['db_version'] = self.param_required('ens_version')
         if self.param_required('wipe_one'):
             options['wipe'] = True
-
+        # add loader option such as page_size, base_site for testing
         db_url_parts = parse.urlparse(self.param_required('db_url'))
-        assert db_url_parts.scheme in ('mysql')
+        assert db_url_parts.scheme in ('mysql',)
         assert db_url_parts.path != ''
         if db_url_parts.scheme == 'mysql':
             assert db_url_parts.port != ''
@@ -68,9 +68,9 @@ class OLSHiveLoader(eHive.BaseRunnable):
         logger = logging.getLogger('ols_errors')
         logger.addHandler(ols_error_handler)
         logger.setLevel(logging.ERROR)
+        options['output_dir'] = self.param_required('output_dir')
         self.ols_loader = OlsLoader(self.param_required('db_url'), **options)
         self.ols_loader.init_meta()
-        assert self.param_required('ontology_name') in self.ols_loader.allowed_ontologies
 
     def run(self):
         raise RuntimeError('This class is not meant to be an actual Hive Wrapper')

--- a/bio/ensembl/ontology/hive/OLSImportReport.py
+++ b/bio/ensembl/ontology/hive/OLSImportReport.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+# @author Marc Chakiachvili
+import logging
+
+from .OLSHiveLoader import OLSHiveLoader
+
+logger = logging.getLogger(__name__)
+
+
+class OLSImportReport(OLSHiveLoader):
+    """ Dedicated loader for Ontology main page"""
+
+    def run(self):
+        # False => erreur marque le job en failed, i.e pas de retry
+        self.input_job.transient_error = False
+        logger.info('Creating loading report for %s', self.param_required('ontology_name'))
+        assert self.param_required('ontology_name') in self.ols_loader.allowed_ontologies
+
+        self.ols_loader.final_report(self.param_required('ontology_name'))
+        self.dataflow({'ontology_name': self.param_required('ontology_name'),
+                       'report_file': self.ols_loader.get_report_logger().handlers[0].baseFilename})
+
+    def write_output(self):
+        logger.info('Ontology %s done...', self.param_required('ontology_name'))

--- a/bio/ensembl/ontology/hive/OLSOntologyLoader.py
+++ b/bio/ensembl/ontology/hive/OLSOntologyLoader.py
@@ -17,6 +17,7 @@ import logging
 
 from bio.ensembl.ontology.loader.db import dal
 from .OLSHiveLoader import OLSHiveLoader
+from ebi.ols.api.client import OlsClient
 
 logger = logging.getLogger(__name__)
 
@@ -31,12 +32,12 @@ class OLSOntologyLoader(OLSHiveLoader):
         if self.param_required('wipe_one') == 1:
             self.ols_loader.wipe_ontology(self.param_required('ontology_name'))
 
-        with dal.session_scope() as session:
-            m_ontology = self.ols_loader.load_ontology(self.param_required('ontology_name'))
-            session.add(m_ontology)
-            self.dataflow({'ontology_name': self.param_required('ontology_name'),
-                           'nb_terms': m_ontology.number_of_terms
-                           })
+        assert self.param_required('ontology_name') in self.ols_loader.allowed_ontologies
+        client = OlsClient()
+        m_ontology = client.ontology(self.param_required('ontology_name'))
+        self.dataflow({ 'ontology_name': self.param_required('ontology_name'),
+                        'nb_terms': m_ontology.number_of_terms
+                    })
 
     def write_output(self):
         logger.info('Ontology %s done...', self.param_required('ontology_name'))

--- a/bio/ensembl/ontology/loader/models.py
+++ b/bio/ensembl/ontology/loader/models.py
@@ -118,9 +118,6 @@ class Meta(Base):
     meta_value = Column(String(128))
     species_id = Column(Integer)
 
-    def __repr__(self):
-        return '<Meta(meta_id={}, meta_key={}, meta_value={})>'.format(self.meta_id, self.meta_key, self.meta_value)
-
 
 class Ontology(LoadAble, Base):
     __tablename__ = 'ontology'
@@ -213,10 +210,6 @@ class Term(LoadAble, Base):
         Index('ontology_acc_idx', 'ontology_id', 'accession', unique=True),
         Index('term_name_idx', 'name', mysql_length=100),
         {'mysql_engine': 'MyISAM'}
-    )
-
-    _load_map = dict(
-        accession='obo_id'
     )
 
     def __dir__(self):

--- a/loader.py
+++ b/loader.py
@@ -47,7 +47,5 @@ if __name__ == "__main__":
         logger.info('Ontology %s reset', arguments.ontology)
     logger.info('Loading ontology %s', arguments.ontology)
     with dal.session_scope() as session:
-        m_ontology = loader.load_ontology(arguments.ontology)
-        session.add(m_ontology)
-        n_terms = loader.load_ontology_terms(m_ontology)
+        n_terms = loader.load_ontology_terms(arguments.ontology)
     logger.info('...Done')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.20.0
 SQLAlchemy==1.2.11
-ebi-ols-client==1.0.5
+ebi-ols-client==1.0.6
 mysqlclient==1.3.13
 dateutils==0.6.6
 coreapi==2.3.3


### PR DESCRIPTION
- expected terms to be inserted
- ignored terms
- report from result DB
- removed __call_client for retry, now done directly inside ols-client.