### PR TITLE
EP-4829: Test using dockerized DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ venv.bak/
 *.db
 *.sqlite
 tmp/*
+
+# dev test environment
+tests/.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tests/ols-docker"]
+	path = tests/ols-docker
+	url = https://github.com/radome/OLS-docker.git
+	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
 python:
-  - "3.6"
+  - "3.5"
 # command to install dependencies
 services:
   - mysql
+  - docker
+before_install:
+  - docker build -t ols tests/ols-docker
+  - docker run -d -p 127.0.0.1:8080:8080 -t ols
+  - docker ps -a
 install:
   - pip install -r requirements.txt
   - pip install nose
   - pip install coverage
   - pip install python-coveralls
-env:
-  - DB_TEST_URL=mysql+pymysql://root:@localhost:3306/ols_test_ontology?charset=utf8&autocommit=true
 # command to run tests
 script:
   - nosetests tests.test_basic --verbose --with-coverage --cover-package=bio.ensembl

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 EnsEMBL - Ontology MySQL Loader
 
-Copyright [2018-2019] EMBL-European Bioinformatics Institute
+Copyright [2018-2020] EMBL-European Bioinformatics Institute
 
 This product includes software developed at
 EMBL-European Bioinformatics Institute (https://www.ebi.ac.uk).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-requests==2.20.0
+git+git://github.com/radome/ols-client@EP-4829_docker_test#egg=ebi-ols-client
+requests==2.22.0
 SQLAlchemy==1.2.11
-ebi-ols-client==1.0.8
+# ebi-ols-client==1.0.8
 mysqlclient==1.3.13
 dateutils==0.6.6
 coreapi==2.3.3

--- a/scripts/loader.py
+++ b/scripts/loader.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     arguments = parser.parse_args(sys.argv[1:])
     logger.setLevel(logging.INFO)
     # logging.ERROR if arguments.verbose is None else logging.INFO if arguments.verbose is False else logging.DEBUG)
-    print('Script arguments: ', arguments)
+    logger.info('Script arguments: {}'.format(arguments))
     args = vars(parser.parse_args())
     db_name = 'ensembl_ontology_{}'.format(arguments.release)
     options = {'drop': not arguments.keep, 'echo': arguments.verbose, 'db_version': arguments.release}
@@ -69,14 +69,14 @@ if __name__ == "__main__":
         slices = arguments.slice.split('-')
     else:
         slices = None
-    print('Db Url set to:', db_url)
-    print('Loader arguments:', db_url, options)
-    print('Slices: ', slices)
+    logger.info('Db Url set to: {}'.format(db_url))
+    logger.info('Loader arguments: {} {}'.format(db_url, options))
+    logger.info('Slices: {}'.format(slices))
 
     response = input("Confirm to proceed (y/N)? ")
 
     if response.upper() != 'Y':
-        logging.info('Process cancelled')
+        logger.info('Process cancelled')
         exit(0)
 
     loader = OlsLoader(db_url, **options)

--- a/tests/.env.dist
+++ b/tests/.env.dist
@@ -1,0 +1,7 @@
+[DEFAULT]
+DB_TEST_URL = mysql+pymysql://root@localhost:3306/test_ols_ontology?charset=utf8&autocommit=true
+OLS_API_URL = https://www.ebi.ac.uk/ols/api
+
+[ols-docker]
+DB_TEST_URL = mysql+pymysql://root@localhost:3306/test_ols_ontology?charset=utf8&autocommit=true
+OLS_API_URL = http://localhost:8080/api

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -58,10 +58,10 @@ def read_env():
 read_env()
 
 
-class TestOLSLoader(unittest.TestCase):
+class TestOLSLoaderRemote(unittest.TestCase):
     _multiprocess_shared_ = False
     db_url = os.getenv('DB_TEST_URL', 'mysql+pymysql://root@localhost:3306/ols_test_ontology?charset=utf8&autocommit=true')
-    ols_api_url = os.getenv('OLS_API_URL', 'https://www.ebi.ac.uk/ols/api')
+    ols_api_url = 'https://www.ebi.ac.uk/ols/api'
 
     @classmethod
     def setUpClass(cls):
@@ -79,82 +79,271 @@ class TestOLSLoader(unittest.TestCase):
     def tearDown(self):
         dal.wipe_schema(self.db_url)
 
-    def testLoadOntology(self):
-        # test retrieve
-        # test try to create duplicated
-        ontology_name = 'CVDO'
+    def testGoExpectedLinks(self):
+        go_term = [
+            'GO_0005575',
+            'GO_0003674',
+            'GO_0008150',
+        ]
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            terms = self.loader.load_ontology_terms('GO', 0, 20)
+            ontologies = session.query(Ontology).filter_by(name='GO')
+            namespaces = [onto.namespace for onto in ontologies]
+            self.assertSetEqual(set(['go', 'biological_process', 'cellular_component', 'molecular_function']),
+                                set(namespaces))
+            GO_0005575 = session.query(Term).filter_by(accession='GO:0005575').one()
+            GO_0003674 = session.query(Term).filter_by(accession='GO:0003674').one()
+            GO_0008150 = session.query(Term).filter_by(accession='GO:0008150').one()
+            self.assertEqual('biological_process', GO_0008150.ontology.namespace)
+            self.assertEqual('cellular_component', GO_0005575.ontology.namespace)
+            self.assertEqual('molecular_function', GO_0003674.ontology.namespace)
+
+    def testPartOfRelationship(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = False
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0032042",
+                                        ontology_name='GO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'GO', session)
+            self.assertIn('part_of', o_term.relations_types)
+            self.assertIn('part_of', [relation.relation_type.name for relation in m_term.parent_terms])
+            self.assertIn('occurs_in', [relation.relation_type.name for relation in m_term.parent_terms])
+
+    def testChebi(self):
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
+        self.loader.load_ontology_terms('CHEBI', start=1200, end=1250)
+        session = dal.get_session()
+        subsets = session.query(Subset).all()
+        for subset in subsets:
+            self.assertNotEqual(subset.definition, subset.name)
+
+    def testSubsetEco(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/ECO_0000305",
+                                        ontology_name='ECO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'ECO', session)
+            session.commit()
+            subsets = session.query(Subset).all()
+            subsets_name = [sub.name for sub in subsets]
+            term_subsets = m_term.subsets.split(',')
+            self.assertEqual(set(subsets_name), set(term_subsets))
+            for definition in subsets:
+                self.assertIsNotNone(definition)
+
+    def testTermInvalidDefinition(self):
+        '''
+        Term has invalid characters in the definition (e.g. "\\n")
+        '''
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0090481",
+                                        ontology_name='GO', type=helpers.Term)
+            if '\n' not in o_term.description:
+                self.skipTest("Term Description does not contain invalid characters.")
+            else:
+                m_term = self.loader.load_term(o_term, 'GO', session)
+                self.assertNotIn('\n', m_term.description)
+
+    def testTermNoDefinition(self):
+        '''
+        Term does not declared a definition neither within annotation, label is therefore inserted
+        '''
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/MONDO_0020003",
+                                        ontology_name='MONDO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'MONDO', session)
+            self.assertEqual(m_term.name, m_term.description.lower())
+
+    def testLongTermDefinition(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/UBERON_0000948",
+                                        ontology_name='UBERON', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'UBERON', session)
+            for syn in m_term.synonyms:
+                self.assertNotEqual(syn.name, '')
+
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/MONDO_0004933",
+                                        ontology_name='MONDO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'MONDO', session)
+            for syn in m_term.synonyms:
+                self.assertNotEqual(syn.name, '')
+
+    def testGoTerm(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0030118",
+                                        ontology_name='GO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'GO', session)
+            session.add(m_term)
+            self.assertIn('GO:0030117', [rel.parent_term.accession for rel in m_term.parent_terms])
+            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0030131",
+                                        ontology_name='GO', type=helpers.Term)
+            m_term = self.loader.load_term(o_term, 'GO', session)
+            session.add(m_term)
+            self.assertIn('GO:0030119', [rel.parent_term.accession for rel in m_term.parent_terms if
+                                         rel.relation_type.name == 'is_a'])
+            self.assertIn('GO:0030118', [rel.parent_term.accession for rel in m_term.parent_terms if
+                                         rel.relation_type.name == 'part_of'])
+
+    def testExternalRelationship(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            o_term = self.client.term(identifier='http://www.ebi.ac.uk/efo/EFO_0002911', unique=True, silent=True)
+            m_term = self.loader.load_term(o_term, 'EFO', session)
+            session.add(m_term)
+            found = False
+            for relation in m_term.parent_terms:
+                found = found or (relation.parent_term.accession == 'OBI:0000245')
+        self.assertTrue(found)
+        session = dal.get_session()
+        ontologies = session.query(Ontology).filter_by(name='OBI').count()
+        # assert that OBI has not been inserted
+        self.assertEqual(0, ontologies)
+
+    def testMissingOboId(self):
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
+        with dal.session_scope() as session:
+            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/PR_P68993', unique=True, silent=True)
+            m_term = self.loader.load_term(o_term, 'PR', session)
+            self.assertEqual(m_term.accession, 'PR:P68993')
+
+    def testSubsetErrors(self):
+        with dal.session_scope() as session:
+            o_term = self.client.term(identifier='http://www.ebi.ac.uk/efo/EFO_0003503')
+            m_term = self.loader.load_term(o_term, 'EFO', session)
+            session.add(m_term)
+            self.assertIsInstance(session.query(Subset).filter_by(name='efo_slim').one(), Subset)
+
+    def testRelationSingleTerm(self):
+        with dal.session_scope() as session:
+            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/ECO_0007571')
+            m_term = self.loader.load_term(o_term, 'ECO', session)
+            session.add(m_term)
+            session.commit()
+
+    def testTrickTerm(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = False
 
         with dal.session_scope() as session:
-            m_ontology = self.loader.load_ontology(ontology_name, session)
-            logger.info('Loaded ontology %s', m_ontology)
-            logger.info('number of Terms %s', m_ontology.number_of_terms)
-            r_ontology = session.query(Ontology).filter_by(name=ontology_name,
-                                                           namespace='cvdo').one()
-            ontology_id = r_ontology.id
-            logger.info('(RE) Loaded ontology %s', r_ontology)
-            self.assertEqual(m_ontology.name, r_ontology.name)
-            self.assertEqual(m_ontology.version, r_ontology.version)
-            assert isinstance(r_ontology, Ontology)
-            # automatically create another one with another namespace
-            new_ontology, created = get_one_or_create(Ontology,
-                                                      session,
-                                                      name=r_ontology.name,
-                                                      namespace='another_namespace')
+            # o_term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0001330')
+            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/FYPO_0001330', unique=True,
+                                      silent=True)
+            m_term = self.loader.load_term(o_term, 'fypo', session)
+            session.add(m_term)
+            found = False
+            for relation in m_term.parent_terms:
+                found = found or (relation.parent_term.accession == 'CHEBI:24431')
+        self.assertTrue(found)
 
-            self.assertTrue(created)
-            for i in range(0, 5):
-                session.add(Term(accession='CCC_00000{}'.format(i),
-                                 name='Term {}'.format(i),
-                                 ontology=r_ontology,
-                                 is_root=False,
-                                 is_obsolete=False))
-            self.assertTrue(new_ontology.name == r_ontology.name)
+    def testAltIds(self):
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
 
-        session = dal.get_session()
-        self.assertEqual(5, session.query(Term).filter_by(ontology_id=ontology_id).count())
-        ontologies = session.query(Ontology).filter_by(name=ontology_name)
-        self.assertEqual(ontologies.count(), 2)
-        self.loader.final_report(ontology_name)
-        self.assertTrue(os.path.isfile(ontology_name + '_report.log'))
-
-    def testLoadOntologyTerms(self):
-        session = dal.get_session()
-        ontology_name = 'CIO'
-        self.loader.load_ontology(ontology_name, session)
-        expected, ignored = self.loader.load_ontology_terms(ontology_name)
-        logger.info('Expected terms %s', expected)
-        s_terms = session.query(Term).filter(Ontology.name == ontology_name)
-        inserted = s_terms.count()
-        logger.info('Inserted terms %s', inserted)
-        self.assertEqual(expected, inserted)
-        logger.info('Testing unknown ontology')
-        with self.assertRaises(NotFoundException):
-            expected, ignored = self.loader.load_ontology_terms('unknownontology')
-            self.assertEqual(0, expected)
-
-    def testLoadTimeMeta(self):
-        ontology_name = 'BFO'
-        self.loader.options['wipe'] = True
-        self.loader.options['db_version'] = '99'
-        self.loader.init_meta()
         with dal.session_scope() as session:
-            m_ontology = self.loader.load_ontology(ontology_name, session)
+            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/GO_0005261')
+            m_term = self.loader.load_term(o_term, 'AERO', session)
+            session.add(m_term)
+            self.assertGreaterEqual(len(m_term.alt_ids), 2)
+
+    def testSubsets(self):
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
+
+        with dal.session_scope() as session:
+            term = helpers.Term(ontology_name='go', iri='http://purl.obolibrary.org/obo/GO_0099565')
+            o_term = self.client.detail(term)
+            m_term = self.loader.load_term(o_term, 'go', session)
+            session.add(m_term)
+            subsets = session.query(Subset).all()
+            for subset in subsets:
+                self.assertIsNotNone(subset.definition)
+
+            subset = helpers.Property(ontology_name='go',
+                                      iri='http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym')
+            details = self.client.detail(subset)
+            self.assertNotEqual(details.definition, '')
+
+    def testRelationOtherOntology(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+        with dal.session_scope() as session:
+            m_ontology = self.loader.load_ontology('efo', session)
             session.add(m_ontology)
-            self.assertIsInstance(m_ontology, Ontology)
+            term = helpers.Term(ontology_name='efo', iri='http://www.ebi.ac.uk/efo/EFO_0002215')
+            o_term = self.client.detail(term)
+            m_term = self.loader.load_term(o_term, m_ontology, session)
+            session.add(m_term)
+            self.assertGreaterEqual(session.query(Ontology).count(), 2)
+            term = session.query(Term).filter_by(accession='BTO:0000164')
+            self.assertEqual(1, term.count())
+
+    def testRelationsShips(self):
+        with dal.session_scope() as session:
+            m_ontology = self.loader.load_ontology('bto', session)
+            session.add(m_ontology)
+            term = helpers.Term(ontology_name='bto', iri='http://purl.obolibrary.org/obo/BTO_0000005')
+            o_term = self.client.detail(term)
+            m_term = self.loader.load_term(o_term, m_ontology, session)
+            session.add(m_term)
+            self.assertGreaterEqual(len(m_term.parent_terms), 0)
+
+    def testOntologiesList(self):
+        self.assertIsInstance(self.loader.allowed_ontologies, list)
+        self.assertIn('GO', self.loader.allowed_ontologies)
+
+    def testSingleTerm(self):
+        self.loader.options['process_relations'] = True
+        self.loader.options['process_parents'] = True
+
+        with dal.session_scope() as session:
+            m_ontology = self.loader.load_ontology('fypo', session)
+            session.add(m_ontology)
+            term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0000257')
+            o_term = self.client.detail(term)
+            m_term = self.loader.load_term(o_term, m_ontology, session)
+            session.commit()
+            self.assertGreaterEqual(len(m_term.parent_terms), 4)
+
+            self.loader.options['process_relations'] = False
+            self.loader.options['process_parents'] = False
+            o_ontology = self.client.ontology('GO')
+            term = helpers.Term(ontology_name='GO', iri='http://purl.obolibrary.org/obo/GO_0000002')
+            o_term = self.client.detail(term)
+            print(o_term.description, o_term.label)
+            m_term = self.loader.load_term(o_term, o_ontology, session)
+            self.assertEqual(m_term.ontology.name, 'GO')
+            with self.assertRaises(RuntimeError):
+                self.loader.load_term(o_term, 33, session)
+
+    def testEncodingTerm(self):
+        self.loader.options['process_relations'] = False
+        self.loader.options['process_parents'] = False
         session = dal.get_session()
-        meta_file_date = session.query(Meta).filter_by(meta_key=ontology_name + '_file_date').one()
-        meta_start = session.query(Meta).filter_by(meta_key=ontology_name + '_load_date').one()
-        meta_schema = session.query(Meta).filter_by(meta_key='patch').one()
-        self.assertEqual('patch_98_99_a.sql|schema version', meta_schema.meta_value)
-        self.assertTrue(
-            datetime.datetime.strptime(meta_start.meta_value, ontology_name.upper() + "/%c") < datetime.datetime.now())
-        logger.debug('meta load_all date: %s', meta_start)
-        logger.debug('meta file date: %s', meta_file_date)
-        try:
-            datetime.datetime.strptime(meta_file_date.meta_value, ontology_name.upper() + "/%c")
-            datetime.datetime.strptime(meta_start.meta_value, ontology_name.upper() + "/%c")
-        except ValueError:
-            self.fail('Wrong date format')
+        m_ontology = self.loader.load_ontology('fypo', session)
+        session.add(m_ontology)
+        term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0005645')
+        o_term = self.client.detail(term)
+        m_term = self.loader.load_term(o_term, m_ontology, session)
+        dal.get_session().commit()
+        self.assertTrue(isinstance(m_term.description, str))
+        if 'λ' in o_term.description:
+            self.assertIn('λ', m_term.description)
+        else:
+            self.skipTest("Character not present in retrieved term from OLS")
 
     def testCascadeDelete(self):
         if 'mysql' not in self.db_url:
@@ -196,7 +385,8 @@ class TestOLSLoader(unittest.TestCase):
 
         with dal.session_scope() as session:
             self.loader.wipe_ontology('GO')
-            [self.assertTrue(term.accession.startswith('T3')) for term in session.query(Term).all()]
+            for term in session.query(Term).all():
+                self.assertTrue(term.accession.startswith('T3'))
             self.assertEqual(0, session.query(Term).filter(Term.ontology_id == 1).count())
             self.assertEqual(session.query(Term).count(), 5)
             self.assertEqual(session.query(Synonym).count(), 0)
@@ -204,301 +394,139 @@ class TestOLSLoader(unittest.TestCase):
             self.assertEqual(session.query(Relation).count(), 0)
             self.assertEqual(session.query(Closure).count(), 0)
 
+    def testLoadTimeMeta(self):
+        ontology_name = 'BFO'
+        self.loader.options['wipe'] = True
+        self.loader.options['db_version'] = '99'
+        self.loader.init_meta()
+        with dal.session_scope() as session:
+            m_ontology = self.loader.load_ontology(ontology_name, session)
+            session.add(m_ontology)
+            self.assertIsInstance(m_ontology, Ontology)
+        session = dal.get_session()
+        meta_file_date = session.query(Meta).filter_by(meta_key=ontology_name + '_file_date').one()
+        meta_start = session.query(Meta).filter_by(meta_key=ontology_name + '_load_date').one()
+        meta_schema = session.query(Meta).filter_by(meta_key='patch').one()
+        self.assertEqual('patch_98_99_a.sql|schema version', meta_schema.meta_value)
+        self.assertTrue(
+            datetime.datetime.strptime(meta_start.meta_value, ontology_name.upper() + "/%c") < datetime.datetime.now())
+        logger.debug('meta load_all date: %s', meta_start)
+        logger.debug('meta file date: %s', meta_file_date)
+        try:
+            datetime.datetime.strptime(meta_file_date.meta_value, ontology_name.upper() + "/%c")
+            datetime.datetime.strptime(meta_start.meta_value, ontology_name.upper() + "/%c")
+        except ValueError:
+            self.fail('Wrong date format')
+
+    def testLoadOntologyTerms(self):
+        session = dal.get_session()
+        ontology_name = 'CIO'
+        self.loader.load_ontology(ontology_name, session)
+        expected, ignored = self.loader.load_ontology_terms(ontology_name)
+        logger.info('Expected terms %s', expected)
+        s_terms = session.query(Term).filter(Ontology.name == ontology_name)
+        inserted = s_terms.count()
+        logger.info('Inserted terms %s', inserted)
+        self.assertEqual(expected, inserted)
+        logger.info('Testing unknown ontology')
+        with self.assertRaises(NotFoundException):
+            expected, ignored = self.loader.load_ontology_terms('unknownontology')
+            self.assertEqual(0, expected)
+
+    def testLoadOntology(self):
+        # test retrieve
+        # test try to create duplicated
+        ontology_name = 'CVDO'
+
+        with dal.session_scope() as session:
+            m_ontology = self.loader.load_ontology(ontology_name, session)
+            logger.info('Loaded ontology %s', m_ontology)
+            logger.info('number of Terms %s', m_ontology.number_of_terms)
+            r_ontology = session.query(Ontology).filter_by(name=ontology_name,
+                                                           namespace='cvdo').one()
+            ontology_id = r_ontology.id
+            logger.info('(RE) Loaded ontology %s', r_ontology)
+            self.assertEqual(m_ontology.name, r_ontology.name)
+            self.assertEqual(m_ontology.version, r_ontology.version)
+            assert isinstance(r_ontology, Ontology)
+            # automatically create another one with another namespace
+            new_ontology, created = get_one_or_create(Ontology,
+                                                      session,
+                                                      name=r_ontology.name,
+                                                      namespace='another_namespace')
+
+            self.assertTrue(created)
+            for i in range(0, 5):
+                session.add(Term(accession='CCC_00000{}'.format(i),
+                                 name='Term {}'.format(i),
+                                 ontology=r_ontology,
+                                 is_root=False,
+                                 is_obsolete=False))
+            self.assertTrue(new_ontology.name == r_ontology.name)
+
+        session = dal.get_session()
+        self.assertEqual(5, session.query(Term).filter_by(ontology_id=ontology_id).count())
+        ontologies = session.query(Ontology).filter_by(name=ontology_name)
+        self.assertEqual(ontologies.count(), 2)
+        self.loader.final_report(ontology_name)
+        self.assertTrue(os.path.isfile(ontology_name + '_report.log'))
+
+
+class TestOLSLoaderBasic(unittest.TestCase):
+    _multiprocess_shared_ = False
+    db_url = os.getenv('DB_TEST_URL', 'mysql+pymysql://root@localhost:3306/ols_test_ontology?charset=utf8&autocommit=true')
+    ols_api_url = os.getenv('OLS_API_URL', 'http://localhost:8080/api')
+
+    @classmethod
+    def setUpClass(cls):
+        logger.info('Using %s connexion string', cls.db_url)
+        try:
+            dal.wipe_schema(cls.db_url)
+        except sqlalchemy.exc.InternalError as e:
+            logger.info("Unable to wipe schema %s", e)
+
+    def setUp(self):
+        warnings.simplefilter("ignore", ResourceWarning)
+        self.loader = OlsLoader(self.db_url, echo=False, output_dir='.')
+        self.client = OlsClient(base_site=self.ols_api_url)
+
+    def tearDown(self):
+        dal.wipe_schema(self.db_url)
+
     def testMeta(self):
         session = dal.get_session()
         self.loader.init_meta()
         metas = session.query(Meta).all()
         self.assertGreaterEqual(len(metas), 2)
 
-    def testEncodingTerm(self):
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-        session = dal.get_session()
-        m_ontology = self.loader.load_ontology('fypo', session)
-        session.add(m_ontology)
-        term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0005645')
-        o_term = self.client.detail(term)
-        m_term = self.loader.load_term(o_term, m_ontology, session)
-        dal.get_session().commit()
-        self.assertTrue(isinstance(m_term.description, str))
-        if 'λ' in o_term.description:
-            self.assertIn('λ', m_term.description)
-        else:
-            self.skipTest("Character not present in retrieved term from OLS")
-
-    def testSingleTerm(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-
-        with dal.session_scope() as session:
-            m_ontology = self.loader.load_ontology('fypo', session)
-            session.add(m_ontology)
-            term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0000257')
-            o_term = self.client.detail(term)
-            m_term = self.loader.load_term(o_term, m_ontology, session)
-            session.commit()
-            self.assertGreaterEqual(len(m_term.parent_terms), 4)
-
-            self.loader.options['process_relations'] = False
-            self.loader.options['process_parents'] = False
-            o_ontology = self.client.ontology('GO')
-            term = helpers.Term(ontology_name='GO', iri='http://purl.obolibrary.org/obo/GO_0000002')
-            o_term = self.client.detail(term)
-            print(o_term.description, o_term.label)
-            m_term = self.loader.load_term(o_term, o_ontology, session)
-            self.assertEqual(m_term.ontology.name, 'GO')
-            with self.assertRaises(RuntimeError):
-                self.loader.load_term(o_term, 33, session)
-
-    def testOntologiesList(self):
-        self.assertIsInstance(self.loader.allowed_ontologies, list)
-        self.assertIn('GO', self.loader.allowed_ontologies)
-
-    def testRelationsShips(self):
-        with dal.session_scope() as session:
-            m_ontology = self.loader.load_ontology('bto', session)
-            session.add(m_ontology)
-            term = helpers.Term(ontology_name='bto', iri='http://purl.obolibrary.org/obo/BTO_0000005')
-            o_term = self.client.detail(term)
-            m_term = self.loader.load_term(o_term, m_ontology, session)
-            session.add(m_term)
-            self.assertGreaterEqual(len(m_term.parent_terms), 0)
-
-    def testRelationOtherOntology(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            m_ontology = self.loader.load_ontology('efo', session)
-            session.add(m_ontology)
-            term = helpers.Term(ontology_name='efo', iri='http://www.ebi.ac.uk/efo/EFO_0002215')
-            o_term = self.client.detail(term)
-            m_term = self.loader.load_term(o_term, m_ontology, session)
-            session.add(m_term)
-            self.assertGreaterEqual(session.query(Ontology).count(), 2)
-            term = session.query(Term).filter_by(accession='BTO:0000164')
-            self.assertEqual(1, term.count())
-
-    def testSubsets(self):
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-
-        with dal.session_scope() as session:
-            term = helpers.Term(ontology_name='go', iri='http://purl.obolibrary.org/obo/GO_0099565')
-            o_term = self.client.detail(term)
-            m_term = self.loader.load_term(o_term, 'go', session)
-            session.add(m_term)
-            subsets = session.query(Subset).all()
-            for subset in subsets:
-                self.assertIsNotNone(subset.definition)
-
-            subset = helpers.Property(ontology_name='go',
-                                      iri='http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym')
-            details = self.client.detail(subset)
-            self.assertNotEqual(details.definition, '')
-
-    def testAltIds(self):
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-
-        with dal.session_scope() as session:
-            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/GO_0005261')
-            m_term = self.loader.load_term(o_term, 'go', session)
-            session.add(m_term)
-            self.assertGreaterEqual(len(m_term.alt_ids), 2)
-
-    def testTrickTerm(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = False
-
-        with dal.session_scope() as session:
-            # o_term = helpers.Term(ontology_name='fypo', iri='http://purl.obolibrary.org/obo/FYPO_0001330')
-            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/FYPO_0001330', unique=True,
-                                      silent=True)
-            m_term = self.loader.load_term(o_term, 'fypo', session)
-            session.add(m_term)
-            found = False
-            for relation in m_term.parent_terms:
-                found = found or (relation.parent_term.accession == 'CHEBI:24431')
-        self.assertTrue(found)
-
     def testRelatedNonExpected(self):
         self.loader.options['process_relations'] = True
         self.loader.options['process_parents'] = True
         with dal.session_scope() as session:
-            ontology_name = 'ECO'
-            expected, ignored = self.loader.load_ontology_terms(ontology_name, start=0, end=50)
+            ontology_name = 'AERO'
+            expected, _ignored = self.loader.load_ontology_terms(ontology_name, start=0, end=50)
             logger.info('Expected terms %s', expected)
             s_terms = session.query(Term).filter(Ontology.name == ontology_name)
             inserted = s_terms.count()
             logger.info('Inserted terms %s', inserted)
             self.assertGreaterEqual(inserted, expected)
 
-    def testRelationSingleTerm(self):
-        with dal.session_scope() as session:
-            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/ECO_0007571')
-            m_term = self.loader.load_term(o_term, 'ECO', session)
-            session.add(m_term)
-            session.commit()
-
-    def testSubsetErrors(self):
-        with dal.session_scope() as session:
-            o_term = self.client.term(identifier='http://www.ebi.ac.uk/efo/EFO_0003503')
-            m_term = self.loader.load_term(o_term, 'EFO', session)
-            session.add(m_term)
-            self.assertIsInstance(session.query(Subset).filter_by(name='efo_slim').one(), Subset)
-
-    def testMissingOboId(self):
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-        with dal.session_scope() as session:
-            o_term = self.client.term(identifier='http://purl.obolibrary.org/obo/PR_P68993', unique=True, silent=True)
-            m_term = self.loader.load_term(o_term, 'PR', session)
-            self.assertEqual(m_term.accession, 'PR:P68993')
-
-    def testExternalRelationship(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            o_term = self.client.term(identifier='http://www.ebi.ac.uk/efo/EFO_0002911', unique=True, silent=True)
-            m_term = self.loader.load_term(o_term, 'EFO', session)
-            session.add(m_term)
-            found = False
-            for relation in m_term.parent_terms:
-                found = found or (relation.parent_term.accession == 'OBI:0000245')
-        self.assertTrue(found)
-        session = dal.get_session()
-        ontologies = session.query(Ontology).filter_by(name='OBI').count()
-        # assert that OBI has not been inserted
-        self.assertEqual(0, ontologies)
-
-    def testGoTerm(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0030118",
-                                        ontology_name='GO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'GO', session)
-            session.add(m_term)
-            self.assertIn('GO:0030117', [rel.parent_term.accession for rel in m_term.parent_terms])
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0030131",
-                                        ontology_name='GO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'GO', session)
-            session.add(m_term)
-            self.assertIn('GO:0030119', [rel.parent_term.accession for rel in m_term.parent_terms if
-                                         rel.relation_type.name == 'is_a'])
-            self.assertIn('GO:0030118', [rel.parent_term.accession for rel in m_term.parent_terms if
-                                         rel.relation_type.name == 'part_of'])
-
-    def testLongTermDefinition(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/UBERON_0000948",
-                                        ontology_name='UBERON', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'UBERON', session)
-            for syn in m_term.synonyms:
-                self.assertNotEqual(syn.name, '')
-
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/MONDO_0004933",
-                                        ontology_name='MONDO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'MONDO', session)
-            for syn in m_term.synonyms:
-                self.assertNotEqual(syn.name, '')
-
-    def testTermNoDefinition(self):
-        '''
-        Term does not declared a definition neither within annotation, label is therefore inserted
-        '''
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/MONDO_0020003",
-                                        ontology_name='MONDO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'MONDO', session)
-            self.assertEqual(m_term.name, m_term.description.lower())
-
-    def testTermInvalidDefinition(self):
-        '''
-        Term has invalid characters in the definition (e.g. "\\n")
-        '''
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0090481",
-                                        ontology_name='GO', type=helpers.Term)
-            if '\n' not in o_term.description:
-                self.skipTest("Term Description does not contain invalid characters.")
-            else:
-                m_term = self.loader.load_term(o_term, 'GO', session)
-                self.assertNotIn('\n', m_term.description)
-
-    def testSubsetEco(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/ECO_0000305",
-                                        ontology_name='ECO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'ECO', session)
-            session.commit()
-            subsets = session.query(Subset).all()
-            subsets_name = [sub.name for sub in subsets]
-            term_subsets = m_term.subsets.split(',')
-            self.assertEqual(set(subsets_name), set(term_subsets))
-            [self.assertIsNotNone(definition) for definition in subsets]
-
-    def testChebi(self):
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = False
-        self.loader.load_ontology_terms('CHEBI', start=1200, end=1250)
-        session = dal.get_session()
-        subsets = session.query(Subset).all()
-        [self.assertNotEqual(subset.definition, subset.name) for subset in subsets]
-
     def testLoadRelatedSynonyms(self):
         self.loader.options['process_relations'] = False
         self.loader.options['process_parents'] = False
 
     def testUpperCase(self):
-        ontology_name = 'ogms'
+        ontology_name = 'aero'
         self.loader.options['process_relations'] = False
         with dal.session_scope() as session:
             m_ontology = self.loader.load_ontology(ontology_name, session)
             session.add(m_ontology)
-            self.assertEqual(m_ontology.name, 'OGMS')
+            self.assertEqual(m_ontology.name, 'AERO')
             onto_id = m_ontology.id
             logger.info("Ontololgy name in DB %s", m_ontology.name)
-            self.loader.load_ontology_terms('ogms', 0, 50)
+            self.loader.load_ontology_terms('aero', 0, 50)
             terms = session.query(Term).all()
-            [self.assertTrue(term.ontology_id == onto_id) for term in terms if term.ontology.name == 'OGMS']
+            for term in terms:
+                if term.ontology.name == 'AERO':
+                    self.assertTrue(term.ontology_id == onto_id)
 
-    def testGoExpectedLinks(self):
-        go_term = [
-            'GO_0005575',
-            'GO_0003674',
-            'GO_0008150',
-        ]
-        self.loader.options['process_relations'] = False
-        self.loader.options['process_parents'] = True
-        with dal.session_scope() as session:
-            terms = self.loader.load_ontology_terms('GO', 0, 20)
-            ontologies = session.query(Ontology).filter_by(name='GO')
-            namespaces = [onto.namespace for onto in ontologies]
-            self.assertSetEqual(set(['go', 'biological_process', 'cellular_component', 'molecular_function']),
-                                set(namespaces))
-            GO_0005575 = session.query(Term).filter_by(accession='GO:0005575').one()
-            GO_0003674 = session.query(Term).filter_by(accession='GO:0003674').one()
-            GO_0008150 = session.query(Term).filter_by(accession='GO:0008150').one()
-            self.assertEqual('biological_process', GO_0008150.ontology.namespace)
-            self.assertEqual('cellular_component', GO_0005575.ontology.namespace)
-            self.assertEqual('molecular_function', GO_0003674.ontology.namespace)
-
-    def testPartOfRelationship(self):
-        self.loader.options['process_relations'] = True
-        self.loader.options['process_parents'] = False
-        with dal.session_scope() as session:
-            o_term = self.client.detail(iri="http://purl.obolibrary.org/obo/GO_0032042",
-                                        ontology_name='GO', type=helpers.Term)
-            m_term = self.loader.load_term(o_term, 'GO', session)
-            self.assertIn('part_of', o_term.relations_types)
-            self.assertIn('part_of', [relation.relation_type.name for relation in m_term.parent_terms])
-            self.assertIn('occurs_in', [relation.relation_type.name for relation in m_term.parent_terms])


### PR DESCRIPTION
- Using experimental [radome/ols-client](https://github.com/radome/ols-client/tree/EP-4829_docker_test)
- Add test class for running tests using a separate client connected to a different API endpoint
- Add [radome/OLS-docker](https://github.com/radome/OLS-docker) as a submodule to tests
- Update `.travis.yml` to build and start OLS-docker container