### PR TITLE
increase name column size in subset table

### DIFF
--- a/bio/ensembl/ontology/loader/models.py
+++ b/bio/ensembl/ontology/loader/models.py
@@ -204,7 +204,7 @@ class Subset(LoadAble, Base):
         return ['subset_id', 'name', 'definition']
 
     subset_id = Column(UnsignedInt, primary_key=True)
-    name = Column(String(64), nullable=False, unique=True)
+    name = Column(String(100), nullable=False, unique=True)
     definition = Column(BigStringUtf8, nullable=True, server_default=text("''"))
 
 


### PR DESCRIPTION
Fix for EFO Term , subset names  greater than the varchar 64